### PR TITLE
Downgrade to MySQL 5.7.26

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -53,7 +53,7 @@ services:
       - REGISTRY_COMPATIBILITY_SCHEMA1_ENABLED=true
       - REGISTRY_HTTP_HOST=https://registry.hub.cellery.io:9090
   mysql.hub.internal:
-    image: mysql:8.0.16
+    image: mysql:5.7.26
     restart: always
     volumes:
       - ./mysql/dbscripts:/docker-entrypoint-initdb.d


### PR DESCRIPTION
## Purpose
> Downgrade to MySQL 5.7.26 in favour of WSO2 IS

## Goals
> Downgrade to MySQL 5.7.26 in favour of WSO2 IS

## Approach
> Downgrade to MySQL 5.7.26 in favour of WSO2 IS

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A