### PR TITLE
Turn off skip hostname verification and added a skew time

### DIFF
--- a/components/api/constants/constants.bal
+++ b/components/api/constants/constants.bal
@@ -53,3 +53,5 @@ public const string UPDATED_DATE = "UPDATED_DATE";
 
 public const string CACHE_EXPIRY_VAR = "token.cache.expiry";
 public const string CACHE_CAPACITY_VAR = "token.cache.capacity";
+
+public const string SKEW_TIME = "skew.time";

--- a/components/api/filter/validator-filter.bal
+++ b/components/api/filter/validator-filter.bal
@@ -129,15 +129,16 @@ type CookieNotFoundData record {
 
 type CookieNotFoundError error<string, CookieNotFoundData>;
 
-function isExpired(int timeVal) returns boolean {
+function isExpired(int idpServerTime) returns boolean {
     log:printDebug("Token expiry time will be evaluated");
     time:Time time = time:currentTime();
+    log:printDebug(io:sprintf("Adding a skew time of %d", config:getAsInt(constants:SKEW_TIME)));
     int timeNow = time.time;
-    if (timeNow/1000 < timeVal) {
+    if (timeNow/1000 < (idpServerTime + config:getAsInt(constants:SKEW_TIME))) {
         return false;
     } else {
-        log:printDebug(io:sprintf("The system time is %d and the expiry time is %d",
-        timeNow/1000, timeVal));
+        log:printDebug(io:sprintf("The system time is %d and the expiry time of idp server is %d",
+        timeNow/1000, idpServerTime));
         return true;
     }
 }

--- a/components/docker-auth/cmd/authn/authentication.go
+++ b/components/docker-auth/cmd/authn/authentication.go
@@ -211,14 +211,16 @@ func validateAccessToken(token string, providedUsername string, execId string) b
 	}
 	username, password := resolveCredentials(execId)
 	req.SetBasicAuth(username, password)
-	// todo Remove the the host verification turning off
 	certificateInUse, err := readCert(idpCertEnvVar, execId)
 	caCertPool := x509.NewCertPool()
 	caCertPool.AppendCertsFromPEM(certificateInUse)
-	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs:      caCertPool,
+			},
+		},
 	}
-	client := &http.Client{Transport: tr}
 	res, err := client.Do(req)
 	if err != nil {
 		log.Printf("[%s] Error sending the request to the introspection endpoint : %s\n", execId, err)

--- a/components/docker-auth/cmd/authn/authentication.go
+++ b/components/docker-auth/cmd/authn/authentication.go
@@ -217,7 +217,7 @@ func validateAccessToken(token string, providedUsername string, execId string) b
 	client := &http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
-				RootCAs:      caCertPool,
+				RootCAs: caCertPool,
 			},
 		},
 	}

--- a/deployment/api/conf/api.toml
+++ b/deployment/api/conf/api.toml
@@ -35,6 +35,9 @@ password="admin"
 cache.expiry=1800000
 cache.capacity=500
 
+[skew]
+time=300
+
 [b7a.log]
 level="DEBUG"
 


### PR DESCRIPTION
## Purpose
> Turn off skip hostname verification
> Currently in token validation, If there is the idp server time lesser than the api server time. Then api will try go and fetch  a new token. Then the same token will be issued since the token in idp server is not expired. This skew time will avoid such scenarios.


