### PR TITLE
Hide update and delete options when image version is not found

### DIFF
--- a/components/portal/node-server/config/portal.json
+++ b/components/portal/node-server/config/portal.json
@@ -1,9 +1,9 @@
 {
-    "hubPublicUrl": "https://hub.cellery.io:9000",
-    "hubApiUrl": "https://api.hub.cellery.io:11000/api/0.1.0",
+    "hubPublicUrl": "https://hub.cellery.io",
+    "hubApiUrl": "https://api.hub.cellery.io/api/0.1.0",
     "reCaptchaSiteKey": "fillme",
     "idp": {
-        "url": "https://idp.hub.cellery.io:9443",
+        "url": "https://idp.hub.cellery.io",
         "hubClientId": "celleryhubapplication",
         "sdkClientId": "cellerycliapplication"
     }

--- a/components/portal/package.json
+++ b/components/portal/package.json
@@ -22,7 +22,7 @@
     "vis": "^4.21.0"
   },
   "scripts": {
-    "start": "concurrently --kill-others --names \"config-server,webpack-dev-server\" \"APP_ENV=DEV PORTAL_PORT=4000 node node-server/serve.js\" \"react-scripts start\"",
+    "start": "concurrently --kill-others --names \"config-server,webpack-dev-server\" \"APP_ENV=DEV PORTAL_PORT=4000 node node-server/serve.js\" \"HTTPS=true HOST=hub.cellery.io PORT=443 react-scripts start\"",
     "build": "react-scripts build",
     "lint": "eslint --color src/",
     "lint:fix": "eslint --color --fix src/",

--- a/components/portal/src/components/image/dependencyDiagram/index.js
+++ b/components/portal/src/components/image/dependencyDiagram/index.js
@@ -30,7 +30,7 @@ const styles = (theme) => ({
     }
 });
 
-const DependencyDiagram = ({data, classes, history}) => {
+const DependencyDiagram = ({data, classes, onClickNode}) => {
     const getFQN = (nodeData) => `${nodeData.org}/${nodeData.name}:${nodeData.ver}`;
     const focusedNodeFQN = getFQN(data);
     const diagramData = {
@@ -143,10 +143,7 @@ const DependencyDiagram = ({data, classes, history}) => {
     return (
         <div className={classes.content}>
             <CellDiagram data={diagramData} focusedNode={`${data.org}/${data.name}:${data.ver}`}
-                onClickNode={(nodeId) => {
-                    const nodeUrl = nodeId.replace(/:/g, "/");
-                    history.push(`/images/${nodeUrl}`);
-                }}/>
+                onClickNode={onClickNode}/>
         </div>
     );
 };
@@ -155,9 +152,7 @@ DependencyDiagram.propTypes = {
     data: PropTypes.object.isRequired,
     classes: PropTypes.object.isRequired,
     focusedNode: PropTypes.string.isRequired,
-    history: PropTypes.shape({
-        push: PropTypes.func.isRequired
-    })
+    onClickNode: PropTypes.func.isRequired
 };
 
 export default withStyles(styles)(withRouter(DependencyDiagram));

--- a/components/portal/src/components/image/index.js
+++ b/components/portal/src/components/image/index.js
@@ -507,7 +507,7 @@ class Image extends React.Component {
                                                 </div>
                                             </div>
                                             {
-                                                imageData.keywords.length > 0
+                                                imageData.keywords && imageData.keywords.length > 0
                                                     ? (
                                                         <div className={classes.keywords}>
                                                             <Typography variant={"subtitle2"} color={"inherit"}

--- a/components/portal/src/components/image/index.js
+++ b/components/portal/src/components/image/index.js
@@ -507,7 +507,7 @@ class Image extends React.Component {
                                                 </div>
                                             </div>
                                             {
-                                                imageData.keywords
+                                                imageData.keywords.length > 0
                                                     ? (
                                                         <div className={classes.keywords}>
                                                             <Typography variant={"subtitle2"} color={"inherit"}

--- a/components/portal/src/components/image/version/index.js
+++ b/components/portal/src/components/image/version/index.js
@@ -335,7 +335,13 @@ class ImageVersion extends React.Component {
         const tabs = [
             {
                 label: "Dependencies",
-                render: () => <DependencyDiagram data={versionData.metadata}/>
+                render: () => <DependencyDiagram data={versionData.metadata} onClickNode={(nodeId) => {
+                    const nodeUrl = nodeId.replace(/:/g, "/");
+                    history.push(`/images/${nodeUrl}`);
+                    this.setState({
+                        versionData: null
+                    });
+                }}/>
             },
             {
                 label: "Description",


### PR DESCRIPTION
## Purpose
When the user clicks on a node in the dependency diagram which is not there in the hub,  the edit/delete more option is displayed on along with the image version not found message. 